### PR TITLE
PHP 7.2 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"type": "library",
 	"require": {
 		"php": ">= 5.6.0",
-		"nette/utils": "2.3.*",
+		"nette/utils": "^2.4",
 		"guzzlehttp/guzzle": "^6.2"
 	},
 	"require-dev": {

--- a/src/JsonRpc/Client.php
+++ b/src/JsonRpc/Client.php
@@ -2,14 +2,16 @@
 
 namespace Achse\GethJsonRpcPhpClient\JsonRpc;
 
-use Nette\Object;
+use Nette\SmartObject;
 use Nette\Utils\Json;
 use stdClass;
 
 
 
-class Client extends Object
+class Client
 {
+
+	use SmartObject;
 
 	const JSON_RPC_VERSION = '2.0';
 

--- a/src/JsonRpc/GuzzleClientFactory.php
+++ b/src/JsonRpc/GuzzleClientFactory.php
@@ -3,12 +3,13 @@
 namespace Achse\GethJsonRpcPhpClient\JsonRpc;
 
 use GuzzleHttp\Client as GuzzleHttpClient;
-use Nette\Object;
+use Nette\SmartObject;
 
 
 
-class GuzzleClientFactory extends Object
+class GuzzleClientFactory
 {
+	use SmartObject;
 
 	/**
 	 * @param string[] $options

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,12 +2,15 @@
 
 namespace Achse\GethJsonRpcPhpClient;
 
-use Nette\Object;
+use Nette\SmartObject;
+use function bcadd;
+use function bcmul;
+use function bcpow;
 
 
-
-class Utils extends Object
+class Utils
 {
+	use SmartObject;
 
 	/**
 	 * @see http://stackoverflow.com/questions/1273484/large-hex-values-with-php-hexdec


### PR DESCRIPTION
Use `nette/utils 2.4` and newer
Use `Nette\SmartObject` trait instead of extending (now forbidden) `Nette\Object`

I'm not sure if this breaks PHP 7 compat, but I think it shouldn't